### PR TITLE
Add block 'head' to _bootstrap.pug

### DIFF
--- a/_bootstrap.pug
+++ b/_bootstrap.pug
@@ -46,15 +46,16 @@ include components/bootswatch
 doctype html
 html(lang="en")
 	head
-		meta(charset="UTF-8")
-		meta(http-equiv="X-UA-Compatible", content="IE=edge")
-		meta(name="viewport",content="width=device-width, initial-scale=1")
-		meta(name="description",content="")
-		meta(name="author",content="")
-		link(rel="icon",href="../../favicon.ico")
-		title= title
-		block styles
-			link(rel="stylesheet",href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css")
+		block head
+			meta(charset="UTF-8")
+			meta(http-equiv="X-UA-Compatible", content="IE=edge")
+			meta(name="viewport",content="width=device-width, initial-scale=1")
+			meta(name="description",content="")
+			meta(name="author",content="")
+			link(rel="icon",href="../../favicon.ico")
+			title= title
+			block styles
+				link(rel="stylesheet",href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css")
 	body(data-spy="scroll",data-target=".scrollspy")
 		block body
 			


### PR DESCRIPTION
Its really nice to be able to prepend/replace/append the head element, but there is no head block to allow me to do so :(

I have added a block head inside the head element to facilitate downstream customization of the head element's contents.

```pug
extends node_modules/pug-bootstrap/_bootstrap.pug

append head
    script(src="/path/to/my/script")
```